### PR TITLE
Moved non-requirement imports | Encoding support

### DIFF
--- a/mbr_nmt/io.py
+++ b/mbr_nmt/io.py
@@ -2,9 +2,9 @@ import re
 
 EOS_TOKEN = "</s>"
 
-def read_samples_file(filename, num_samples, add_eos=False):
+def read_samples_file(filename, num_samples, add_eos=False, encoding=None):
     samples = []
-    with open(filename, "r") as f:
+    with open(filename, "r", encoding=encoding) as f:
         for line_id, line in enumerate(f.readlines()):
             if line_id % num_samples == 0:
                 if line_id != 0: samples.append(samples_i)
@@ -19,10 +19,10 @@ def read_samples_file(filename, num_samples, add_eos=False):
 
     return samples
 
-def read_candidates_file(filename, add_eos=False):
+def read_candidates_file(filename, add_eos=False, encoding=None):
     candidates = []
     candidates_i = None
-    with open(filename, "r") as f:
+    with open(filename, "r", encoding=encoding) as f:
         for line_id, line in enumerate(f.readlines()):
             if candidates_i is None:
                 try:
@@ -51,8 +51,8 @@ def read_candidates_file(filename, add_eos=False):
 
     return candidates
 
-def wc(filename):
+def wc(filename, encoding=None):
     count = 0
-    with open(filename, "r") as f:
+    with open(filename, "r", encoding=encoding) as f:
         count += sum(1 for line in f)
     return count


### PR DESCRIPTION
I wanted to use vanilla MBR to rerank generations from an English-Czech system on a Windows machine, but ran into some issues.

1. Importing `bayes_mc_mbr` from `mbr_nmt.bayesmc` threw issues with `gpytorch `and `GPy`. Since these are not in the requirements, I move the import statements to after checking the MBR algorithm. Now, the `mbr` function works out of the box.
2. I/O operations in my terminal expected an encoding method not compatible with utf-8. I added an `encoding` variable to the argparser, and left its default value as `None` for the argparser and every function that opened a file. Behaviour should remain the same without specifying another encoding.

I only tested an 'installation > translate with MBR > convert output file' pipeline.